### PR TITLE
Switch from if-none-match to if-not-exists in exclusive write routine

### DIFF
--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -360,7 +360,7 @@ impl OutputFile {
     pub async fn write_exclusive(&self, bs: Bytes) -> crate::Result<()> {
         self.op
             .write_with(&self.path[self.relative_path_pos..], bs)
-            .if_none_match("*")
+            .if_not_exists(true)
             .await?;
         Ok(())
     }


### PR DESCRIPTION
This is because there is an opendal check now with the former being forbiden for S3 now.