### PR TITLE
Expose file_io.list

### DIFF
--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -110,6 +110,16 @@ impl FileIO {
         Ok(op.exists(relative_path).await?)
     }
 
+    /// List the path and all nested dirs and files recursively.
+    ///
+    /// # Arguments
+    ///
+    /// * path: It should be *absolute* path starting with scheme string used to construct [`FileIO`].
+    pub async fn list(&self, path: impl AsRef<str>) -> Result<Vec<opendal::Entry>> {
+        let (op, relative_path) = self.inner.create_operator(&path)?;
+        Ok(op.list(relative_path).await?)
+    }
+
     /// Creates input file.
     ///
     /// # Arguments


### PR DESCRIPTION
Expose underlying operator list method through `file_io.list`.

Analogous to PR https://github.com/splitgraph/iceberg-rust/pull/1 which exposed a conditional put method