### PR TITLE
Expose OpenDAL operator in InputFile/OutputFile

### DIFF
--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -291,6 +291,11 @@ impl InputFile {
     pub async fn reader(&self) -> crate::Result<impl FileRead> {
         Ok(self.op.reader(&self.path[self.relative_path_pos..]).await?)
     }
+
+    /// Underlying operator
+    pub fn operator(&self) -> &Operator {
+        &self.op
+    }
 }
 
 /// Trait for writing file.

--- a/crates/iceberg/src/io/file_io.rs
+++ b/crates/iceberg/src/io/file_io.rs
@@ -375,6 +375,11 @@ impl OutputFile {
             self.op.writer(&self.path[self.relative_path_pos..]).await?,
         ))
     }
+
+    /// Underlying operator
+    pub fn operator(&self) -> &Operator {
+        &self.op
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Expose InputFile.operator and OutputFile.operator. As discussed in previous PRs, this allows us to remove wrappers like Operator.write_exclusive