### PR TITLE
Avoid store mixing for different paths

### DIFF
--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -261,6 +261,25 @@ impl TableProvider for DataFusionTable {
     }
 }
 
+// Create a fake object store URL. Different table paths should produce fake URLs
+// that differ in the host name, because DF's DefaultObjectStoreRegistry only takes
+// hostname into account
+fn fake_object_store_url(table_location_url: &str) -> Option<ObjectStoreUrl> {
+    let mut u = url::Url::parse(&table_location_url).ok()?;
+    u.set_host(Some(&format!(
+        "{}{}",
+        u.host_str().unwrap_or("-"),
+        u.path()
+            .replace(object_store::path::DELIMITER, "-")
+            .replace(':', "-")
+    )))
+    .unwrap();
+    u.set_path("");
+    u.set_query(None);
+    u.set_fragment(None);
+    ObjectStoreUrl::parse(u.to_string()).ok()
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn table_scan(
     table: &Table,
@@ -278,8 +297,8 @@ async fn table_scan(
         .unwrap_or_else(|| table.current_schema(None).unwrap().clone());
 
     // Create a unique URI for this particular object store
-    let object_store_url = ObjectStoreUrl::parse(&table.metadata().location)
-        .unwrap_or_else(|_| ObjectStoreUrl::local_filesystem());
+    let object_store_url = fake_object_store_url(&table.metadata().location)
+        .unwrap_or_else(|| ObjectStoreUrl::local_filesystem());
     session
         .runtime_env()
         .register_object_store(object_store_url.as_ref(), table.object_store());
@@ -872,7 +891,9 @@ fn value_to_scalarvalue(value: &Value) -> Result<ScalarValue, DataFusionError> {
 #[cfg(test)]
 mod tests {
 
-    use datafusion::{arrow::array::Int64Array, prelude::SessionContext};
+    use datafusion::{
+        arrow::array::Int64Array, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
+    };
     use iceberg_rust::{
         catalog::tabular::Tabular,
         object_store::ObjectStoreBuilder,
@@ -895,7 +916,7 @@ mod tests {
 
     use std::{ops::Deref, sync::Arc};
 
-    use crate::{catalog::catalog::IcebergCatalog, DataFusionTable};
+    use crate::{catalog::catalog::IcebergCatalog, table::fake_object_store_url, DataFusionTable};
 
     #[tokio::test]
     pub async fn test_datafusion_table_insert() {
@@ -1642,5 +1663,14 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_fake_object_store_url() {
+        assert_eq!(
+            fake_object_store_url("s3://aaa/bbb/ccc"),
+            Some(ObjectStoreUrl::parse("s3://aaa-bbb-ccc").unwrap()),
+        );
+        assert_eq!(fake_object_store_url("invalid url"), None);
     }
 }

--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -269,7 +269,7 @@ fn fake_object_store_url(table_location_url: &str) -> Option<ObjectStoreUrl> {
     u.set_host(Some(&format!(
         "{}-{}",
         u.host_str().unwrap_or(""),
-        // Append hex-encoded path to ensure we get a valid hostname
+        // Hex-encode the path to ensure it produces a valid hostname
         u.path()
             .as_bytes()
             .iter()


### PR DESCRIPTION
With REST vended credentials, object store instances should not be reused for different table paths. This is because the vended credentials for `s3://some-bucket/table-1` might not have access to `s3://some-bucket/table-2`.

In this PR we produce a fake object store URL derived from the path. This means different table paths get different object store instances.