### PR TITLE
Respect other dialects when updating representation

### DIFF
--- a/iceberg-rust/src/view/transaction/operation.rs
+++ b/iceberg-rust/src/view/transaction/operation.rs
@@ -47,13 +47,13 @@ fn upsert_representation(
     let mut updated = false;
     let mut representations: Vec<ViewRepresentation> = current_representations
         .iter()
-        .filter_map(
+        .map(
             |current_representation @ ViewRepresentation::Sql { dialect, .. }| {
                 if dialect == new_dialect {
                     updated = true;
-                    Some(new_representation.clone())
+                    new_representation.clone()
                 } else {
-                    Some(current_representation.clone())
+                    current_representation.clone()
                 }
             },
         )

--- a/iceberg-rust/src/view/transaction/operation.rs
+++ b/iceberg-rust/src/view/transaction/operation.rs
@@ -37,7 +37,7 @@ pub enum Operation {
 
 // Tries to preserve dialect order
 fn upsert_representation(
-    current_representations: &Vec<ViewRepresentation>,
+    current_representations: &[ViewRepresentation],
     new_representation: ViewRepresentation,
 ) -> Vec<ViewRepresentation> {
     let ViewRepresentation::Sql {
@@ -57,7 +57,6 @@ fn upsert_representation(
                 }
             },
         )
-        .map(|v| v.clone())
         .collect();
     if !updated {
         representations.push(new_representation);


### PR DESCRIPTION
With this PR, `Operation::UpdateRepresentation` preserves representations in other dialects instead of overwriting them