### PR TITLE
Allow updating multiple view representations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3218,6 +3218,7 @@ dependencies = [
  "chrono",
  "derive-getters",
  "derive_builder",
+ "flate2",
  "futures",
  "getrandom 0.3.2",
  "iceberg-rust-spec",

--- a/datafusion_iceberg/src/table.rs
+++ b/datafusion_iceberg/src/table.rs
@@ -261,6 +261,29 @@ impl TableProvider for DataFusionTable {
     }
 }
 
+// Create a fake object store URL. Different table paths should produce fake URLs
+// that differ in the host name, because DF's DefaultObjectStoreRegistry only takes
+// hostname into account for object store keys
+fn fake_object_store_url(table_location_url: &str) -> Option<ObjectStoreUrl> {
+    let mut u = url::Url::parse(table_location_url).ok()?;
+    u.set_host(Some(&format!(
+        "{}-{}",
+        u.host_str().unwrap_or(""),
+        // Hex-encode the path to ensure it produces a valid hostname
+        u.path()
+            .as_bytes()
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<Vec<_>>()
+            .join("")
+    )))
+    .unwrap();
+    u.set_path("");
+    u.set_query(None);
+    u.set_fragment(None);
+    ObjectStoreUrl::parse(&u).ok()
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn table_scan(
     table: &Table,
@@ -278,8 +301,8 @@ async fn table_scan(
         .unwrap_or_else(|| table.current_schema(None).unwrap().clone());
 
     // Create a unique URI for this particular object store
-    let object_store_url = ObjectStoreUrl::parse(&table.metadata().location)
-        .unwrap_or_else(|_| ObjectStoreUrl::local_filesystem());
+    let object_store_url = fake_object_store_url(&table.metadata().location)
+        .unwrap_or_else(ObjectStoreUrl::local_filesystem);
     session
         .runtime_env()
         .register_object_store(object_store_url.as_ref(), table.object_store());
@@ -359,7 +382,8 @@ async fn table_scan(
 
         let manifests = table
             .manifests(snapshot_range.0, snapshot_range.1)
-            .await.map_err(DataFusionIcebergError::from)?;
+            .await
+            .map_err(DataFusionIcebergError::from)?;
 
         // If there is a filter expression on the partition column, the manifest files to read are pruned.
         let data_files: Vec<ManifestEntry> = if let Some(predicate) = partition_predicates {
@@ -485,7 +509,7 @@ async fn table_scan(
                 .with_pushdown_filters(true)
         } else {
             ParquetSource::default()
-        }
+        },
     );
 
     // Create plan for every partition with delete files
@@ -577,11 +601,14 @@ async fn table_scan(
                             let delete_file_source = Arc::new(
                                 if let Some(physical_predicate) = physical_predicate.clone() {
                                     ParquetSource::default()
-                                        .with_predicate(Arc::clone(&delete_file_schema), physical_predicate)
+                                        .with_predicate(
+                                            Arc::clone(&delete_file_schema),
+                                            physical_predicate,
+                                        )
                                         .with_pushdown_filters(true)
                                 } else {
                                     ParquetSource::default()
-                                }
+                                },
                             );
 
                             let delete_file_scan_config = FileScanConfig::new(
@@ -872,7 +899,9 @@ fn value_to_scalarvalue(value: &Value) -> Result<ScalarValue, DataFusionError> {
 #[cfg(test)]
 mod tests {
 
-    use datafusion::{arrow::array::Int64Array, prelude::SessionContext};
+    use datafusion::{
+        arrow::array::Int64Array, execution::object_store::ObjectStoreUrl, prelude::SessionContext,
+    };
     use iceberg_rust::{
         catalog::tabular::Tabular,
         object_store::ObjectStoreBuilder,
@@ -895,7 +924,7 @@ mod tests {
 
     use std::{ops::Deref, sync::Arc};
 
-    use crate::{catalog::catalog::IcebergCatalog, DataFusionTable};
+    use crate::{catalog::catalog::IcebergCatalog, table::fake_object_store_url, DataFusionTable};
 
     #[tokio::test]
     pub async fn test_datafusion_table_insert() {
@@ -1642,5 +1671,18 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_fake_object_store_url() {
+        assert_eq!(
+            fake_object_store_url("s3://a"),
+            Some(ObjectStoreUrl::parse("s3://a-").unwrap()),
+        );
+        assert_eq!(
+            fake_object_store_url("s3://a/b"),
+            Some(ObjectStoreUrl::parse("s3://a-2f62").unwrap()),
+        );
+        assert_eq!(fake_object_store_url("invalid url"), None);
     }
 }

--- a/iceberg-rust/Cargo.toml
+++ b/iceberg-rust/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 derive-getters = { workspace = true }
 derive_builder = { workspace = true }
+flate2 = { version = "1.1", features = ["zlib-rs"], default-features = false }
 futures = { workspace = true }
 getrandom = { workspace = true }
 iceberg-rust-spec = { path = "../iceberg-rust-spec", version = "0.7.0" }

--- a/iceberg-rust/src/catalog/create.rs
+++ b/iceberg-rust/src/catalog/create.rs
@@ -221,7 +221,7 @@ impl CreateViewBuilder<Option<()>> {
             if version.default_namespace().is_empty() {
                 version.default_namespace = namespace.to_vec()
             }
-            if version.default_catalog().is_none() {
+            if version.default_catalog().is_none() && !catalog.name().is_empty() {
                 version.default_catalog = Some(catalog.name().to_string())
             }
         }
@@ -349,7 +349,7 @@ impl CreateMaterializedViewBuilder {
             if version.default_namespace().is_empty() {
                 version.default_namespace = namespace.to_vec()
             }
-            if version.default_catalog().is_none() {
+            if version.default_catalog().is_none() && !catalog.name().is_empty() {
                 version.default_catalog = Some(catalog.name().to_string())
             }
         }

--- a/iceberg-rust/src/error.rs
+++ b/iceberg-rust/src/error.rs
@@ -20,6 +20,9 @@ pub enum Error {
     /// Conversion error
     #[error("Failed to convert {0} to {1}.")]
     Conversion(String, String),
+    /// Failed to decompress gzip data
+    #[error("Failed to decompress gzip data: {0}")]
+    Decompress(String),
     /// Not found
     #[error("{0} not found.")]
     NotFound(String),

--- a/iceberg-rust/src/materialized_view/transaction/mod.rs
+++ b/iceberg-rust/src/materialized_view/transaction/mod.rs
@@ -41,7 +41,7 @@ impl<'view> Transaction<'view> {
     }
 
     /// Update the schmema of the view
-    pub fn update_representation(
+    pub fn update_representations(
         mut self,
         representations: Vec<ViewRepresentation>,
         schema: StructType,

--- a/iceberg-rust/src/materialized_view/transaction/mod.rs
+++ b/iceberg-rust/src/materialized_view/transaction/mod.rs
@@ -43,12 +43,12 @@ impl<'view> Transaction<'view> {
     /// Update the schmema of the view
     pub fn update_representation(
         mut self,
-        representation: ViewRepresentation,
+        representations: Vec<ViewRepresentation>,
         schema: StructType,
     ) -> Self {
         self.view_operations
-            .push(ViewOperation::UpdateRepresentation {
-                representation,
+            .push(ViewOperation::UpdateRepresentations {
+                representations,
                 schema,
                 branch: self.branch.clone(),
             });

--- a/iceberg-rust/src/object_store/mod.rs
+++ b/iceberg-rust/src/object_store/mod.rs
@@ -31,7 +31,7 @@ impl Display for Bucket<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Bucket::S3(s) => write!(f, "s3://{}", s),
-            Bucket::GCS(s) => write!(f, "gcs://{}", s),
+            Bucket::GCS(s) => write!(f, "gs://{}", s),
             Bucket::Local => write!(f, ""),
         }
     }

--- a/iceberg-rust/src/object_store/store.rs
+++ b/iceberg-rust/src/object_store/store.rs
@@ -205,7 +205,7 @@ mod tests {
             // Add specific checks for `table_metadata` fields if needed
             assert_eq!(table_metadata.table_uuid.to_string(), "fb072c92-a02b-11e9-ae9c-1bb7bc9eca94");
         } else {
-            assert!(false, "Expected TabularMetadata::Table variant");
+            panic!("Expected TabularMetadata::Table variant");
         }
     }
 
@@ -275,7 +275,7 @@ mod tests {
             // Add specific checks for `table_metadata` fields if needed
             assert_eq!(table_metadata.table_uuid.to_string(), "fb072c92-a02b-11e9-ae9c-1bb7bc9eca94");
         } else {
-            assert!(false, "Expected TabularMetadata::Table variant");
+            panic!("Expected TabularMetadata::Table variant");
         }
     }
 
@@ -339,7 +339,7 @@ mod tests {
             // Add specific checks for `view_metadata` fields if needed
             assert_eq!(view_metadata.view_uuid.to_string(), "fa6506c3-7681-40c8-86dc-e36561f83385");
         } else {
-            assert!(false, "Expected TabularMetadata::View variant");
+            panic!("Expected TabularMetadata::View variant");
         }
     }
 
@@ -406,7 +406,7 @@ mod tests {
             // Add specific checks for `view_metadata` fields if needed
             assert_eq!(view_metadata.view_uuid.to_string(), "fa6506c3-7681-40c8-86dc-e36561f83385");
         } else {
-            assert!(false, "Expected TabularMetadata::View variant");
+            panic!("Expected TabularMetadata::View variant");
         }
     }
 

--- a/iceberg-rust/src/object_store/store.rs
+++ b/iceberg-rust/src/object_store/store.rs
@@ -35,15 +35,7 @@ impl<T: ObjectStore> IcebergStore for T {
             .bytes()
             .await?;
 
-        if location.ends_with(".gz.metadata.json") {
-            let mut decoder = GzDecoder::new(&bytes[..]);
-            let mut decompressed_data = Vec::new();
-            decoder.read_to_end(&mut decompressed_data)
-                .map_err(|e| Error::Decompress(e.to_string()))?;
-            serde_json::from_slice(&decompressed_data).map_err(Error::from)
-        } else {
-            serde_json::from_slice(&bytes).map_err(Error::from)
-        }
+        parse_metadata(location, &bytes)
     }
 
     async fn put_metadata(
@@ -91,9 +83,23 @@ fn version_hint_path(original: &str) -> Option<String> {
     )
 }
 
+fn parse_metadata(location: &str, bytes: &[u8]) -> Result<TabularMetadata, Error> {
+    if location.ends_with(".gz.metadata.json") {
+        let mut decoder = GzDecoder::new(bytes);
+        let mut decompressed_data = Vec::new();
+        decoder
+            .read_to_end(&mut decompressed_data)
+            .map_err(|e| Error::Decompress(e.to_string()))?;
+        serde_json::from_slice(&decompressed_data).map_err(Error::from)
+    } else {
+        serde_json::from_slice(bytes).map_err(Error::from)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     #[test]
     fn test_version_hint_path_normal_case() {
@@ -134,5 +140,310 @@ mod tests {
         let input = "/path/to/file.with.multiple.extensions.json";
         let expected = "/path/to/version-hint.text";
         assert_eq!(version_hint_path(input), Some(expected.to_string()));
+    }
+
+    #[test]
+    fn test_parse_metadata_table_plain_json() {
+        let location = "/path/to/metadata/v1.metadata.json";
+        let json_data = r#"
+            {
+                "format-version" : 2,
+                "table-uuid": "fb072c92-a02b-11e9-ae9c-1bb7bc9eca94",
+                "location": "s3://b/wh/data.db/table",
+                "last-sequence-number" : 1,
+                "last-updated-ms": 1515100955770,
+                "last-column-id": 1,
+                "schemas": [
+                    {
+                        "schema-id" : 1,
+                        "type" : "struct",
+                        "fields" :[
+                            {
+                                "id": 1,
+                                "name": "struct_name",
+                                "required": true,
+                                "type": "fixed[1]"
+                            }
+                        ]
+                    }
+                ],
+                "current-schema-id" : 1,
+                "partition-specs": [
+                    {
+                        "spec-id": 1,
+                        "fields": [
+                            {  
+                                "source-id": 4,  
+                                "field-id": 1000,  
+                                "name": "ts_day",  
+                                "transform": "day"
+                            } 
+                        ]
+                    }
+                ],
+                "default-spec-id": 1,
+                "last-partition-id": 1,
+                "properties": {
+                    "commit.retry.num-retries": "1"
+                },
+                "metadata-log": [
+                    {  
+                        "metadata-file": "s3://bucket/.../v1.json",  
+                        "timestamp-ms": 1515100
+                    }
+                ],
+                "sort-orders": [],
+                "default-sort-order-id": 0
+            }
+        "#;
+        let bytes = json_data.as_bytes();
+
+        let result = parse_metadata(location, bytes);
+        assert!(result.is_ok());
+        let metadata = result.unwrap();
+        if let TabularMetadata::Table(table_metadata) = metadata {
+            // Add specific checks for `table_metadata` fields if needed
+            assert_eq!(table_metadata.table_uuid.to_string(), "fb072c92-a02b-11e9-ae9c-1bb7bc9eca94");
+        } else {
+            assert!(false, "Expected TabularMetadata::Table variant");
+        }
+    }
+
+    #[test]
+    fn test_parse_metadata_table_gzipped_json() {
+        let location = "/path/to/metadata/v1.gz.metadata.json";
+        let json_data = r#"
+            {
+                "format-version" : 2,
+                "table-uuid": "fb072c92-a02b-11e9-ae9c-1bb7bc9eca94",
+                "location": "s3://b/wh/data.db/table",
+                "last-sequence-number" : 1,
+                "last-updated-ms": 1515100955770,
+                "last-column-id": 1,
+                "schemas": [
+                    {
+                        "schema-id" : 1,
+                        "type" : "struct",
+                        "fields" :[
+                            {
+                                "id": 1,
+                                "name": "struct_name",
+                                "required": true,
+                                "type": "fixed[1]"
+                            }
+                        ]
+                    }
+                ],
+                "current-schema-id" : 1,
+                "partition-specs": [
+                    {
+                        "spec-id": 1,
+                        "fields": [
+                            {  
+                                "source-id": 4,  
+                                "field-id": 1000,  
+                                "name": "ts_day",  
+                                "transform": "day"
+                            } 
+                        ]
+                    }
+                ],
+                "default-spec-id": 1,
+                "last-partition-id": 1,
+                "properties": {
+                    "commit.retry.num-retries": "1"
+                },
+                "metadata-log": [
+                    {  
+                        "metadata-file": "s3://bucket/.../v1.json",  
+                        "timestamp-ms": 1515100
+                    }
+                ],
+                "sort-orders": [],
+                "default-sort-order-id": 0
+            }
+        "#;
+
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(json_data.as_bytes()).unwrap();
+        let compressed_data = encoder.finish().unwrap();
+
+        let result = parse_metadata(location, &compressed_data);
+        assert!(result.is_ok());
+        let metadata = result.unwrap();
+        if let TabularMetadata::Table(table_metadata) = metadata {
+            // Add specific checks for `table_metadata` fields if needed
+            assert_eq!(table_metadata.table_uuid.to_string(), "fb072c92-a02b-11e9-ae9c-1bb7bc9eca94");
+        } else {
+            assert!(false, "Expected TabularMetadata::Table variant");
+        }
+    }
+
+    #[test]
+    fn test_parse_metadata_view_plain_json() {
+        let location = "/path/to/metadata/v1.metadata.json";
+        let json_data = r#"
+        {
+        "view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",
+        "format-version" : 1,
+        "location" : "s3://bucket/warehouse/default.db/event_agg",
+        "current-version-id" : 1,
+        "properties" : {
+            "comment" : "Daily event counts"
+        },
+        "versions" : [ {
+            "version-id" : 1,
+            "timestamp-ms" : 1573518431292,
+            "schema-id" : 1,
+            "default-catalog" : "prod",
+            "default-namespace" : [ "default" ],
+            "summary" : {
+            "operation" : "create",
+            "engine-name" : "Spark",
+            "engineVersion" : "3.3.2"
+            },
+            "representations" : [ {
+            "type" : "sql",
+            "sql" : "SELECT\n    COUNT(1), CAST(event_ts AS DATE)\nFROM events\nGROUP BY 2",
+            "dialect" : "spark"
+            } ]
+        } ],
+        "schemas": [ {
+            "schema-id": 1,
+            "type" : "struct",
+            "fields" : [ {
+            "id" : 1,
+            "name" : "event_count",
+            "required" : false,
+            "type" : "int",
+            "doc" : "Count of events"
+            }, {
+            "id" : 2,
+            "name" : "event_date",
+            "required" : false,
+            "type" : "date"
+            } ]
+        } ],
+        "version-log" : [ {
+            "timestamp-ms" : 1573518431292,
+            "version-id" : 1
+        } ]
+        }
+        "#;
+        let bytes = json_data.as_bytes();
+
+        let result = parse_metadata(location, bytes);
+        assert!(result.is_ok());
+        let metadata = result.unwrap();
+        if let TabularMetadata::View(view_metadata) = metadata {
+            // Add specific checks for `view_metadata` fields if needed
+            assert_eq!(view_metadata.view_uuid.to_string(), "fa6506c3-7681-40c8-86dc-e36561f83385");
+        } else {
+            assert!(false, "Expected TabularMetadata::View variant");
+        }
+    }
+
+    #[test]
+    fn test_parse_metadata_view_gzipped_json() {
+        let location = "/path/to/metadata/v1.gz.metadata.json";
+        let json_data = r#"
+        {
+        "view-uuid": "fa6506c3-7681-40c8-86dc-e36561f83385",
+        "format-version" : 1,
+        "location" : "s3://bucket/warehouse/default.db/event_agg",
+        "current-version-id" : 1,
+        "properties" : {
+            "comment" : "Daily event counts"
+        },
+        "versions" : [ {
+            "version-id" : 1,
+            "timestamp-ms" : 1573518431292,
+            "schema-id" : 1,
+            "default-catalog" : "prod",
+            "default-namespace" : [ "default" ],
+            "summary" : {
+            "operation" : "create",
+            "engine-name" : "Spark",
+            "engineVersion" : "3.3.2"
+            },
+            "representations" : [ {
+            "type" : "sql",
+            "sql" : "SELECT\n    COUNT(1), CAST(event_ts AS DATE)\nFROM events\nGROUP BY 2",
+            "dialect" : "spark"
+            } ]
+        } ],
+        "schemas": [ {
+            "schema-id": 1,
+            "type" : "struct",
+            "fields" : [ {
+            "id" : 1,
+            "name" : "event_count",
+            "required" : false,
+            "type" : "int",
+            "doc" : "Count of events"
+            }, {
+            "id" : 2,
+            "name" : "event_date",
+            "required" : false,
+            "type" : "date"
+            } ]
+        } ],
+        "version-log" : [ {
+            "timestamp-ms" : 1573518431292,
+            "version-id" : 1
+        } ]
+        }
+        "#;
+
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(json_data.as_bytes()).unwrap();
+        let compressed_data = encoder.finish().unwrap();
+
+        let result = parse_metadata(location, &compressed_data);
+        assert!(result.is_ok());
+        let metadata = result.unwrap();
+        if let TabularMetadata::View(view_metadata) = metadata {
+            // Add specific checks for `view_metadata` fields if needed
+            assert_eq!(view_metadata.view_uuid.to_string(), "fa6506c3-7681-40c8-86dc-e36561f83385");
+        } else {
+            assert!(false, "Expected TabularMetadata::View variant");
+        }
+    }
+
+    #[test]
+    fn test_parse_metadata_invalid_json() {
+        let location = "/path/to/metadata/v1.metadata.json";
+        let invalid_json_data = r#"{"key": "value""#; // Missing closing brace
+        let bytes = invalid_json_data.as_bytes();
+
+        let result = parse_metadata(location, bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_metadata_invalid_gzipped_data() {
+        let location = "/path/to/metadata/v1.gz.metadata.json";
+        let invalid_gzipped_data = b"not a valid gzip";
+
+        let result = parse_metadata(location, invalid_gzipped_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_metadata_empty_bytes() {
+        let location = "/path/to/metadata/v1.metadata.json";
+        let empty_bytes: &[u8] = &[];
+
+        let result = parse_metadata(location, empty_bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_metadata_gzipped_empty_bytes() {
+        let location = "/path/to/metadata/v1.gz.metadata.json";
+        let empty_gzipped_bytes: &[u8] = &[];
+
+        let result = parse_metadata(location, empty_gzipped_bytes);
+        assert!(result.is_err());
     }
 }

--- a/iceberg-rust/src/view/transaction/mod.rs
+++ b/iceberg-rust/src/view/transaction/mod.rs
@@ -30,11 +30,11 @@ impl<'view> Transaction<'view> {
     /// Update the schmema of the view
     pub fn update_representation(
         mut self,
-        representation: ViewRepresentation,
+        representations: Vec<ViewRepresentation>,
         schema: StructType,
     ) -> Self {
-        self.operations.push(ViewOperation::UpdateRepresentation {
-            representation,
+        self.operations.push(ViewOperation::UpdateRepresentations {
+            representations,
             schema,
             branch: self.branch.clone(),
         });

--- a/iceberg-rust/src/view/transaction/mod.rs
+++ b/iceberg-rust/src/view/transaction/mod.rs
@@ -28,7 +28,7 @@ impl<'view> Transaction<'view> {
         }
     }
     /// Update the schmema of the view
-    pub fn update_representation(
+    pub fn update_representations(
         mut self,
         representations: Vec<ViewRepresentation>,
         schema: StructType,

--- a/iceberg-rust/src/view/transaction/operation.rs
+++ b/iceberg-rust/src/view/transaction/operation.rs
@@ -168,21 +168,23 @@ impl Operation {
     }
 }
 
+#[cfg(test)]
 mod tests {
-    use super::upsert_representations;
     use iceberg_rust_spec::view_metadata::ViewRepresentation;
+
+    use crate::view::transaction::operation::upsert_representations;
 
     #[test]
     fn test_upsert_representations() {
         assert_eq!(
             upsert_representations(
-                &vec![
+                &[
                     ViewRepresentation::sql("a1", Some("a")),
-                    ViewRepresentation::sql("b1", Some("b")),
+                    ViewRepresentation::sql("b1", Some("b"))
                 ],
-                &vec![
+                &[
                     ViewRepresentation::sql("b2", Some("b")),
-                    ViewRepresentation::sql("c2", Some("c")),
+                    ViewRepresentation::sql("c2", Some("c"))
                 ]
             ),
             vec![
@@ -193,13 +195,13 @@ mod tests {
         );
         assert_eq!(
             upsert_representations(
-                &vec![
+                &[
                     ViewRepresentation::sql("a1", Some("a")),
-                    ViewRepresentation::sql("b1", Some("b")),
+                    ViewRepresentation::sql("b1", Some("b"))
                 ],
-                &vec![
+                &[
                     ViewRepresentation::sql("c2", Some("c")),
-                    ViewRepresentation::sql("a2", Some("a")),
+                    ViewRepresentation::sql("a2", Some("a"))
                 ]
             ),
             vec![

--- a/iceberg-rust/src/view/transaction/operation.rs
+++ b/iceberg-rust/src/view/transaction/operation.rs
@@ -167,3 +167,46 @@ impl Operation {
         }
     }
 }
+
+mod tests {
+    use super::upsert_representations;
+    use iceberg_rust_spec::view_metadata::ViewRepresentation;
+
+    #[test]
+    fn test_upsert_representations() {
+        assert_eq!(
+            upsert_representations(
+                &vec![
+                    ViewRepresentation::sql("a1", Some("a")),
+                    ViewRepresentation::sql("b1", Some("b")),
+                ],
+                &vec![
+                    ViewRepresentation::sql("b2", Some("b")),
+                    ViewRepresentation::sql("c2", Some("c")),
+                ]
+            ),
+            vec![
+                ViewRepresentation::sql("a1", Some("a")),
+                ViewRepresentation::sql("b2", Some("b")),
+                ViewRepresentation::sql("c2", Some("c")),
+            ]
+        );
+        assert_eq!(
+            upsert_representations(
+                &vec![
+                    ViewRepresentation::sql("a1", Some("a")),
+                    ViewRepresentation::sql("b1", Some("b")),
+                ],
+                &vec![
+                    ViewRepresentation::sql("c2", Some("c")),
+                    ViewRepresentation::sql("a2", Some("a")),
+                ]
+            ),
+            vec![
+                ViewRepresentation::sql("a2", Some("a")),
+                ViewRepresentation::sql("b1", Some("b")),
+                ViewRepresentation::sql("c2", Some("c")),
+            ]
+        );
+    }
+}

--- a/iceberg-rust/src/view/transaction/operation.rs
+++ b/iceberg-rust/src/view/transaction/operation.rs
@@ -23,9 +23,9 @@ use crate::{
 /// View operation
 pub enum Operation {
     /// Update vresion
-    UpdateRepresentation {
+    UpdateRepresentations {
         /// Representation to add
-        representation: ViewRepresentation,
+        representations: Vec<ViewRepresentation>,
         /// Schema of the representation
         schema: StructType,
         /// Branch where to add the representation
@@ -42,12 +42,13 @@ impl Operation {
         metadata: &GeneralViewMetadata<T>,
     ) -> Result<(Option<ViewRequirement>, Vec<ViewUpdate<T>>), Error> {
         match self {
-            Operation::UpdateRepresentation {
-                representation,
+            Operation::UpdateRepresentations {
+                representations,
                 schema,
                 branch,
             } => {
-                let schema_changed = metadata.current_schema(branch.as_deref())
+                let schema_changed = metadata
+                    .current_schema(branch.as_deref())
                     .map(|s| schema != *s.fields())
                     .unwrap_or(true);
 
@@ -56,7 +57,10 @@ impl Operation {
                 let schema_id = if schema_changed {
                     metadata.schemas.keys().max().unwrap_or(&0) + 1
                 } else {
-                    *metadata.current_schema(branch.as_deref()).unwrap().schema_id()
+                    *metadata
+                        .current_schema(branch.as_deref())
+                        .unwrap()
+                        .schema_id()
                 };
                 let last_column_id = schema.iter().map(|x| x.id).max().unwrap_or(0);
 
@@ -68,7 +72,7 @@ impl Operation {
                         engine_name: None,
                         engine_version: None,
                     },
-                    representations: vec![representation],
+                    representations,
                     default_catalog: version.default_catalog.clone(),
                     default_namespace: version.default_namespace.clone(),
                     timestamp_ms: SystemTime::now()


### PR DESCRIPTION
- Changed `Operation::UpdateRepresentation` to `Operation::UpdateRepresentations` which can take multiple representations
- `Operation::UpdateRepresentations` preserves representations in other dialects instead of overwriting them
- View default_catalog property is not set if catalog name is an empty string