### PR TITLE
fix object-store with_config

### DIFF
--- a/catalogs/iceberg-file-catalog/src/lib.rs
+++ b/catalogs/iceberg-file-catalog/src/lib.rs
@@ -713,14 +713,19 @@ pub mod tests {
         let localstack_port = localstack.get_host_port_ipv4(4566).await.unwrap();
 
         let object_store = ObjectStoreBuilder::s3()
-            .with_config("aws_access_key_id".parse().unwrap(), "user")
-            .with_config("aws_secret_access_key".parse().unwrap(), "password")
+            .with_config("aws_access_key_id", "user")
+            .unwrap()
+            .with_config("aws_secret_access_key", "password")
+            .unwrap()
             .with_config(
-                "endpoint".parse().unwrap(),
+                "endpoint",
                 format!("http://{localstack_host}:{localstack_port}"),
             )
-            .with_config("region".parse().unwrap(), "us-east-1")
-            .with_config("allow_http".parse().unwrap(), "true");
+            .unwrap()
+            .with_config("region", "us-east-1")
+            .unwrap()
+            .with_config("allow_http", "true")
+            .unwrap();
         // let object_store = ObjectStoreBuilder::memory();
 
         let iceberg_catalog: Arc<dyn Catalog> = Arc::new(

--- a/catalogs/iceberg-glue-catalog/src/lib.rs
+++ b/catalogs/iceberg-glue-catalog/src/lib.rs
@@ -1063,14 +1063,19 @@ pub mod tests {
         let localstack_port = localstack.get_host_port_ipv4(4566).await.unwrap();
 
         let object_store = ObjectStoreBuilder::s3()
-            .with_config("aws_access_key_id".parse().unwrap(), "user")
-            .with_config("aws_secret_access_key".parse().unwrap(), "password")
+            .with_config("aws_access_key_id", "user")
+            .unwrap()
+            .with_config("aws_secret_access_key", "password")
+            .unwrap()
             .with_config(
-                "endpoint".parse().unwrap(),
+                "endpoint",
                 format!("http://{localstack_host}:{localstack_port}"),
             )
-            .with_config("region".parse().unwrap(), "us-east-1")
-            .with_config("allow_http".parse().unwrap(), "true");
+            .unwrap()
+            .with_config("region", "us-east-1")
+            .unwrap()
+            .with_config("allow_http", "true")
+            .unwrap();
 
         // let object_store = ObjectStoreBuilder::memory();
         let iceberg_catalog: Arc<dyn Catalog> =

--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -726,14 +726,19 @@ pub mod tests {
         let rest_port = rest.get_host_port_ipv4(8181).await.unwrap();
 
         let object_store = ObjectStoreBuilder::s3()
-            .with_config("aws_access_key_id".parse().unwrap(), "user")
-            .with_config("aws_secret_access_key".parse().unwrap(), "password")
+            .with_config("aws_access_key_id", "user")
+            .unwrap()
+            .with_config("aws_secret_access_key", "password")
+            .unwrap()
             .with_config(
-                "endpoint".parse().unwrap(),
+                "endpoint",
                 format!("http://{localstack_host}:{localstack_port}"),
             )
-            .with_config("region".parse().unwrap(), "us-east-1")
-            .with_config("allow_http".parse().unwrap(), "true");
+            .unwrap()
+            .with_config("region", "us-east-1")
+            .unwrap()
+            .with_config("allow_http", "true")
+            .unwrap();
 
         let iceberg_catalog = Arc::new(RestCatalog::new(
             None,

--- a/catalogs/iceberg-sql-catalog/src/lib.rs
+++ b/catalogs/iceberg-sql-catalog/src/lib.rs
@@ -829,14 +829,19 @@ pub mod tests {
         let localstack_port = localstack.get_host_port_ipv4(4566).await.unwrap();
 
         let object_store = ObjectStoreBuilder::s3()
-            .with_config("aws_access_key_id".parse().unwrap(), "user")
-            .with_config("aws_secret_access_key".parse().unwrap(), "password")
+            .with_config("aws_access_key_id", "user")
+            .unwrap()
+            .with_config("aws_secret_access_key", "password")
+            .unwrap()
             .with_config(
-                "endpoint".parse().unwrap(),
+                "endpoint",
                 format!("http://{localstack_host}:{localstack_port}"),
             )
-            .with_config("region".parse().unwrap(), "us-east-1")
-            .with_config("allow_http".parse().unwrap(), "true");
+            .unwrap()
+            .with_config("region", "us-east-1")
+            .unwrap()
+            .with_config("allow_http", "true")
+            .unwrap();
 
         let iceberg_catalog = Arc::new(
             SqlCatalog::new(

--- a/datafusion_iceberg/tests/empty_insert.rs
+++ b/datafusion_iceberg/tests/empty_insert.rs
@@ -44,14 +44,19 @@ pub async fn test_empty_insert() {
     let localstack_port = localstack.get_host_port_ipv4(4566).await.unwrap();
 
     let object_store = ObjectStoreBuilder::s3()
-        .with_config("aws_access_key_id".parse().unwrap(), "user")
-        .with_config("aws_secret_access_key".parse().unwrap(), "password")
+        .with_config("aws_access_key_id", "user")
+        .unwrap()
+        .with_config("aws_secret_access_key", "password")
+        .unwrap()
         .with_config(
-            "endpoint".parse().unwrap(),
+            "endpoint",
             format!("http://{localstack_host}:{localstack_port}"),
         )
-        .with_config("region".parse().unwrap(), "us-east-1")
-        .with_config("allow_http".parse().unwrap(), "true");
+        .unwrap()
+        .with_config("region", "us-east-1")
+        .unwrap()
+        .with_config("allow_http", "true")
+        .unwrap();
 
     let iceberg_catalog_list = Arc::new(
         SqlCatalogList::new("sqlite://", object_store.clone())

--- a/datafusion_iceberg/tests/integration_trino.rs
+++ b/datafusion_iceberg/tests/integration_trino.rs
@@ -185,14 +185,19 @@ async fn integration_trino_rest() {
         .unwrap();
 
     let object_store = ObjectStoreBuilder::s3()
-        .with_config("aws_access_key_id".parse().unwrap(), "user")
-        .with_config("aws_secret_access_key".parse().unwrap(), "password")
+        .with_config("aws_access_key_id", "user")
+        .unwrap()
+        .with_config("aws_secret_access_key", "password")
+        .unwrap()
         .with_config(
-            "endpoint".parse().unwrap(),
+            "endpoint",
             format!("http://{localstack_host}:{localstack_port}"),
         )
-        .with_config("region".parse().unwrap(), "us-east-1")
-        .with_config("allow_http".parse().unwrap(), "true");
+        .unwrap()
+        .with_config("region", "us-east-1")
+        .unwrap()
+        .with_config("allow_http", "true")
+        .unwrap();
 
     let catalog = Arc::new(RestCatalog::new(
         None,

--- a/iceberg-rust/src/object_store/mod.rs
+++ b/iceberg-rust/src/object_store/mod.rs
@@ -149,18 +149,31 @@ impl ObjectStoreBuilder {
         ObjectStoreBuilder::Memory(Arc::new(InMemory::new()))
     }
     /// Set config value for builder
-    pub fn with_config(self, key: ConfigKey, value: impl Into<String>) -> Self {
-        match (self, key) {
-            (ObjectStoreBuilder::Azure(azure), ConfigKey::Azure(key)) => {
-                ObjectStoreBuilder::Azure(Box::new(azure.with_config(key, value)))
+    pub fn with_config(
+        self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Result<Self, Error> {
+        match self {
+            ObjectStoreBuilder::Azure(azure) => {
+                let key: AzureConfigKey = key.into().parse()?;
+                Ok(ObjectStoreBuilder::Azure(Box::new(
+                    azure.with_config(key, value),
+                )))
             }
-            (ObjectStoreBuilder::S3(aws), ConfigKey::AWS(key)) => {
-                ObjectStoreBuilder::S3(Box::new(aws.with_config(key, value)))
+            ObjectStoreBuilder::S3(aws) => {
+                let key: AmazonS3ConfigKey = key.into().parse()?;
+                Ok(ObjectStoreBuilder::S3(Box::new(
+                    aws.with_config(key, value),
+                )))
             }
-            (ObjectStoreBuilder::GCS(gcs), ConfigKey::GCS(key)) => {
-                ObjectStoreBuilder::GCS(Box::new(gcs.with_config(key, value)))
+            ObjectStoreBuilder::GCS(gcs) => {
+                let key: GoogleConfigKey = key.into().parse()?;
+                Ok(ObjectStoreBuilder::GCS(Box::new(
+                    gcs.with_config(key, value),
+                )))
             }
-            (x, _) => x,
+            x => Ok(x),
         }
     }
     /// Create objectstore from template


### PR DESCRIPTION
This PR moves the parsing of the config keys into the `with_config` method of the `ObjectStoreBuilder`. This is to avoid issues where multiple providers use the same config keys and it hence can lead to a mismatch between ObjectStoreBuilder and ConfigKey