### PR TITLE
fix PruneManifests::row_counts to use total live rows

### DIFF
--- a/datafusion_iceberg/src/pruning_statistics.rs
+++ b/datafusion_iceberg/src/pruning_statistics.rs
@@ -132,13 +132,13 @@ impl PruningStatistics for PruneManifests<'_, '_> {
     }
 
     fn row_counts(&self) -> Option<ArrayRef> {
-        ScalarValue::iter_to_array(
-            self.files
-                .iter()
-                .map(|x| x.added_rows_count)
-                .map(ScalarValue::Int64),
-        )
-        .ok()
+        let row_counts = self.files.iter().map(|x| {
+            match (x.added_rows_count, x.existing_rows_count, x.deleted_rows_count) {
+                (Some(a), Some(e), Some(d)) => Some(a + e - d),
+                _ => None,
+            }
+        });
+        ScalarValue::iter_to_array(row_counts.map(ScalarValue::Int64)).ok()
     }
 }
 


### PR DESCRIPTION
`added_rows_count` counts only ADDED-status files in the current snapshot. Manifests carrying EXISTING rows (e.g. after compaction) have `added_rows_count = 0`, causing DataFusion's IS NOT NULL pruning (`null_count != row_count`) to evaluate `0 != 0 = false` and incorrectly prune manifests that contain live data — silently returning empty results.

Uses `added + existing - deleted` for the actual live row count; falls back to `None` (unknown, safe) when any of the three optional fields is absent.

Fixes JanKaul/iceberg-rust#359