### PR TITLE
refactor: restore clean try_from_bytes API, add try_from_bytes_with_hint

### DIFF
--- a/iceberg-rust-spec/src/spec/manifest.rs
+++ b/iceberg-rust-spec/src/spec/manifest.rs
@@ -572,7 +572,7 @@ impl AvroMap<ByteBuf> {
             .into_iter()
             .filter_map(|(k, v)| {
                 let field = schema.get(k as usize)?;
-                Some(Value::try_from_bytes(&v, &field.field_type, None).map(|val| (k, val)))
+                Some(Value::try_from_bytes(&v, &field.field_type).map(|val| (k, val)))
             })
             .collect()
     }

--- a/iceberg-rust-spec/src/spec/manifest_list.rs
+++ b/iceberg-rust-spec/src/spec/manifest_list.rs
@@ -481,11 +481,11 @@ impl FieldSummary {
             contains_nan: value.contains_nan,
             lower_bound: value
                 .lower_bound
-                .map(|x| Value::try_from_bytes(&x, data_type, None))
+                .map(|x| Value::try_from_bytes(&x, data_type))
                 .transpose()?,
             upper_bound: value
                 .upper_bound
-                .map(|x| Value::try_from_bytes(&x, data_type, None))
+                .map(|x| Value::try_from_bytes(&x, data_type))
                 .transpose()?,
         })
     }

--- a/iceberg-rust-spec/src/spec/values.rs
+++ b/iceberg-rust-spec/src/spec/values.rs
@@ -448,13 +448,24 @@ impl Value {
         }
     }
 
-    /// Attempts to create a Value from raw bytes according to a specified type
+    /// Attempts to create a Value from raw bytes according to a specified type.
+    ///
+    /// Assumes Iceberg single-value-serialization encoding. For bytes that
+    /// originate from a different physical encoding (e.g. Parquet statistics),
+    /// use [`Value::try_from_bytes_with_hint`] instead.
+    #[inline]
+    pub fn try_from_bytes(bytes: &[u8], data_type: &Type) -> Result<Self, Error> {
+        Self::try_from_bytes_with_hint(bytes, data_type, None)
+    }
+
+    /// Like [`Value::try_from_bytes`] but accepts an optional [`PhysicalTypeHint`]
+    /// for bytes that don't follow the Iceberg single-value-serialization spec.
     ///
     /// # Arguments
     /// * `bytes` - The raw byte slice to parse
     /// * `data_type` - The expected type of the value
-    /// * `physical_type_hint` - Provide additional information when parsing some
-    ///   data types (e.g. UUID or Decimal)
+    /// * `physical_type_hint` - Encoding hint for UUID or Decimal bytes that
+    ///   deviate from the Iceberg spec (e.g. Parquet INT32/INT64 or BYTE_ARRAY)
     ///
     /// # Returns
     /// * `Ok(Value)` - Successfully parsed value of the specified type
@@ -464,7 +475,7 @@ impl Value {
     /// Currently only supports primitive types. Complex types like structs, lists,
     /// and maps are not supported and will return an error.
     #[inline]
-    pub fn try_from_bytes(
+    pub fn try_from_bytes_with_hint(
         bytes: &[u8],
         data_type: &Type,
         physical_type_hint: Option<PhysicalTypeHint>,
@@ -1122,7 +1133,7 @@ mod tests {
         let schema = apache_avro::Schema::parse_str(raw_schema).unwrap();
 
         let bytes = ByteBuf::from(input);
-        let literal = Value::try_from_bytes(&bytes, expected_type, None).unwrap();
+        let literal = Value::try_from_bytes(&bytes, expected_type).unwrap();
         assert_eq!(literal, expected_literal);
 
         let mut writer = apache_avro::Writer::new(&schema, Vec::new());
@@ -1132,7 +1143,7 @@ mod tests {
 
         for record in reader {
             let result = apache_avro::from_value::<ByteBuf>(&record.unwrap()).unwrap();
-            let desered_literal = Value::try_from_bytes(&result, expected_type, None).unwrap();
+            let desered_literal = Value::try_from_bytes(&result, expected_type).unwrap();
             assert_eq!(desered_literal, expected_literal);
         }
     }
@@ -1440,7 +1451,7 @@ mod tests {
         let value = Value::Decimal(decimal);
         let bytes = (decimal.mantissa() as i64).to_le_bytes();
 
-        let decoded = Value::try_from_bytes(
+        let decoded = Value::try_from_bytes_with_hint(
             &bytes,
             &Type::Primitive(PrimitiveType::Decimal {
                 precision: 18,
@@ -1458,7 +1469,7 @@ mod tests {
         let value = Value::UUID(uuid);
 
         let bytes = uuid.to_string().into_bytes();
-        let decoded = Value::try_from_bytes(
+        let decoded = Value::try_from_bytes_with_hint(
             &bytes,
             &Type::Primitive(PrimitiveType::Uuid),
             Some(PhysicalTypeHint::ByteArray),

--- a/iceberg-rust/src/file_format/parquet.rs
+++ b/iceberg-rust/src/file_format/parquet.rs
@@ -122,8 +122,8 @@ pub fn parquet_to_datafile(
                         statistics.min_bytes_opt(),
                         statistics.max_bytes_opt(),
                     ) {
-                        let min = Value::try_from_bytes(min_bytes, data_type, physical_type_hint)?;
-                        let max = Value::try_from_bytes(max_bytes, data_type, physical_type_hint)?;
+                        let min = Value::try_from_bytes_with_hint(min_bytes, data_type, physical_type_hint)?;
+                        let max = Value::try_from_bytes_with_hint(max_bytes, data_type, physical_type_hint)?;
                         let current_min = lower_bounds.get(&id);
                         let current_max = upper_bounds.get(&id);
                         match (min, max, current_min, current_max) {
@@ -173,7 +173,7 @@ pub fn parquet_to_datafile(
 
                 if let Some(min_bytes) = statistics.min_bytes_opt() {
                     if let Type::Primitive(_) = &data_type {
-                        let new = Value::try_from_bytes(min_bytes, data_type, physical_type_hint)?;
+                        let new = Value::try_from_bytes_with_hint(min_bytes, data_type, physical_type_hint)?;
                         match lower_bounds.entry(id) {
                             Entry::Occupied(mut entry) => {
                                 let entry = entry.get_mut();
@@ -229,7 +229,7 @@ pub fn parquet_to_datafile(
                 }
                 if let Some(max_bytes) = statistics.max_bytes_opt() {
                     if let Type::Primitive(_) = &data_type {
-                        let new = Value::try_from_bytes(max_bytes, data_type, physical_type_hint)?;
+                        let new = Value::try_from_bytes_with_hint(max_bytes, data_type, physical_type_hint)?;
                         match upper_bounds.entry(id) {
                             Entry::Occupied(mut entry) => {
                                 let entry = entry.get_mut();
@@ -293,13 +293,13 @@ pub fn parquet_to_datafile(
                             if let (Some(min_bytes), Some(max_bytes)) =
                                 (statistics.min_bytes_opt(), statistics.max_bytes_opt())
                             {
-                                let min = Value::try_from_bytes(
+                                let min = Value::try_from_bytes_with_hint(
                                     min_bytes,
                                     data_type,
                                     physical_type_hint,
                                 )?
                                 .transform(partition_field.transform())?;
-                                let max = Value::try_from_bytes(
+                                let max = Value::try_from_bytes_with_hint(
                                     max_bytes,
                                     data_type,
                                     physical_type_hint,


### PR DESCRIPTION
## Summary

- Renames the 3-argument `try_from_bytes` added in this PR to `try_from_bytes_with_hint`
- Restores a clean 2-argument `try_from_bytes(bytes, data_type)` that delegates to `try_from_bytes_with_hint` with `None`
- Call sites that don't need a physical-type hint (`manifest.rs`, `manifest_list.rs`, existing tests) go back to the 2-argument form — no `None` scattered everywhere
- Only `parquet.rs` and the two new hint-specific unit tests call `try_from_bytes_with_hint` explicitly
