### PR TITLE
refactor: replace FromResponse trait with fetch_inner + fetch_conditi…

### DIFF
--- a/catalogs/iceberg-rest-catalog/src/apis/catalog_api_api.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/catalog_api_api.rs
@@ -444,7 +444,7 @@ pub async fn commit_transaction(
     let uri_str = "transactions/commit".to_string();
     let method = reqwest::Method::POST;
 
-    fetch::fetch_empty(
+    fetch::fetch(
         configuration,
         method,
         prefix,
@@ -548,7 +548,7 @@ pub async fn drop_namespace(
 
     let method = reqwest::Method::DELETE;
 
-    fetch::fetch_empty(configuration, method, prefix, &uri_str, &(), None, None).await
+    fetch::fetch(configuration, method, prefix, &uri_str, &(), None, None).await
 }
 
 /// Remove a table from the catalog
@@ -571,7 +571,7 @@ pub async fn drop_table(
     );
     let method = reqwest::Method::DELETE;
 
-    fetch::fetch_empty(
+    fetch::fetch(
         configuration,
         method,
         prefix,
@@ -597,7 +597,7 @@ pub async fn drop_view(
     );
     let method = reqwest::Method::DELETE;
 
-    fetch::fetch_empty(configuration, method, prefix, &uri_str, &(), None, None).await
+    fetch::fetch(configuration, method, prefix, &uri_str, &(), None, None).await
 }
 
 /// List all namespaces at a certain level, optionally starting from a given parent namespace. If table accounting.tax.paid.info exists, using 'SELECT NAMESPACE IN accounting' would translate into `GET /namespaces?parent=accounting` and must return a namespace, [\"accounting\", \"tax\"] only. Using 'SELECT NAMESPACE IN accounting.tax' would translate into `GET /namespaces?parent=accounting%1Ftax` and must return a namespace, [\"accounting\", \"tax\", \"paid\"]. If `parent` is not provided, all top-level namespaces should be listed.
@@ -785,17 +785,14 @@ pub async fn load_namespace_metadata(
 ///
 /// The headers argument can control how the Iceberg catalog handles credentials (via
 /// `X-Iceberg-Access-Delegation`) and whether to use HTTP cache semantics (via `If-None-Match`).
-pub async fn load_table<T>(
+pub async fn load_table(
     configuration: &configuration::Configuration,
     prefix: Option<&str>,
     namespace: &str,
     table: &str,
     headers: HashMap<String, String>,
     snapshots: Option<&str>,
-) -> Result<T, Error<LoadTableError>>
-where
-    T: super::FromResponse<LoadTableError>,
-{
+) -> Result<super::Conditional<models::LoadTableResult>, Error<LoadTableError>> {
     let mut query_params = HashMap::new();
     if let Some(snapshots) = snapshots {
         query_params.insert("snapshots".to_owned(), snapshots.to_string());
@@ -807,7 +804,7 @@ where
         table = crate::apis::urlencode(table)
     );
 
-    fetch::fetch(
+    fetch::fetch_conditional(
         configuration,
         reqwest::Method::GET,
         prefix,
@@ -849,7 +846,7 @@ pub async fn namespace_exists(
 
     let method = reqwest::Method::HEAD;
 
-    fetch::fetch_empty(configuration, method, prefix, &uri_str, &(), None, None).await
+    fetch::fetch(configuration, method, prefix, &uri_str, &(), None, None).await
 }
 
 /// Register a table using given metadata file location.
@@ -887,7 +884,7 @@ pub async fn rename_table(
     let uri_str = "tables/rename".to_string();
     let method = reqwest::Method::POST;
 
-    fetch::fetch_empty(
+    fetch::fetch(
         configuration,
         method,
         prefix,
@@ -908,7 +905,7 @@ pub async fn rename_view(
     let uri_str = "views/rename".to_string();
     let method = reqwest::Method::POST;
 
-    fetch::fetch_empty(
+    fetch::fetch(
         configuration,
         method,
         prefix,
@@ -961,7 +958,7 @@ pub async fn report_metrics(
     );
     let method = reqwest::Method::POST;
 
-    fetch::fetch_empty(
+    fetch::fetch(
         configuration,
         method,
         prefix,
@@ -988,7 +985,7 @@ pub async fn table_exists(
 
     let method = reqwest::Method::HEAD;
 
-    fetch::fetch_empty(configuration, method, prefix, &uri_str, &(), None, None).await
+    fetch::fetch(configuration, method, prefix, &uri_str, &(), None, None).await
 }
 
 /// Set and/or remove properties on a namespace. The request body specifies a list of properties to remove and a map of key value pairs to update. Properties that are not in the request are not modified or removed by this call. Server implementations are not required to support namespace properties.
@@ -1058,5 +1055,5 @@ pub async fn view_exists(
 
     let method = reqwest::Method::HEAD;
 
-    fetch::fetch_empty(configuration, method, prefix, &uri_str, &(), None, None).await
+    fetch::fetch(configuration, method, prefix, &uri_str, &(), None, None).await
 }

--- a/catalogs/iceberg-rest-catalog/src/apis/catalog_api_api.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/catalog_api_api.rs
@@ -783,9 +783,44 @@ pub async fn load_namespace_metadata(
 /// Load a table from the catalog. The response contains the table's full metadata plus any extra
 /// configuration to apply to it, which may include credentials to use for subsequent requests.
 ///
-/// The headers argument can control how the Iceberg catalog handles credentials (via
-/// `X-Iceberg-Access-Delegation`) and whether to use HTTP cache semantics (via `If-None-Match`).
+/// The headers argument can control how the Iceberg catalog handles credentials via
+/// `X-Iceberg-Access-Delegation`. For HTTP cache semantics use [`load_table_conditional`].
 pub async fn load_table(
+    configuration: &configuration::Configuration,
+    prefix: Option<&str>,
+    namespace: &str,
+    table: &str,
+    headers: HashMap<String, String>,
+    snapshots: Option<&str>,
+) -> Result<models::LoadTableResult, Error<LoadTableError>> {
+    let mut query_params = HashMap::new();
+    if let Some(snapshots) = snapshots {
+        query_params.insert("snapshots".to_owned(), snapshots.to_string());
+    }
+
+    let uri_str = format!(
+        "namespaces/{namespace}/tables/{table}",
+        namespace = crate::apis::urlencode(namespace),
+        table = crate::apis::urlencode(table)
+    );
+
+    fetch::fetch(
+        configuration,
+        reqwest::Method::GET,
+        prefix,
+        &uri_str,
+        &(),
+        Some(headers),
+        Some(query_params),
+    )
+    .await
+}
+
+/// Load a table from the catalog with HTTP cache semantics. Pass an `If-None-Match` header with
+/// a previously received ETag to skip re-fetching unchanged metadata; the server returns
+/// `304 Not Modified` in that case and this function returns [`super::Conditional::NotModified`].
+/// Use [`load_table`] when caching is not needed.
+pub async fn load_table_conditional(
     configuration: &configuration::Configuration,
     prefix: Option<&str>,
     namespace: &str,

--- a/catalogs/iceberg-rest-catalog/src/apis/fetch.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/fetch.rs
@@ -2,76 +2,9 @@ use crate::apis::{configuration, ResponseContent};
 
 use super::{Conditional, Error};
 
-use async_trait::async_trait;
 use std::collections::HashMap;
 
-/// Turns a raw [`reqwest::Response`] into the caller's chosen output type. The output type
-/// selects how the response is interpreted, so a single [`fetch`] serves every case:
-/// - a `Deserialize` type parses the JSON body (an empty body is treated as `null`, so `()`
-///   works for endpoints with no content);
-/// - [`Conditional<T>`] additionally honours `304 Not Modified` and captures the response `ETag`.
-#[async_trait]
-pub trait FromResponse<E>: Sized {
-    async fn from_response(resp: reqwest::Response) -> Result<Self, Error<E>>;
-}
-
-#[async_trait]
-impl<T, E> FromResponse<E> for T
-where
-    T: serde::de::DeserializeOwned,
-    E: serde::de::DeserializeOwned,
-{
-    async fn from_response(resp: reqwest::Response) -> Result<Self, Error<E>> {
-        let status = resp.status();
-        let content = resp.text().await?;
-        if !status.is_client_error() && !status.is_server_error() {
-            let body = if content.is_empty() { "null" } else { &content };
-            serde_json::from_str(body).map_err(Error::from)
-        } else {
-            let entity: Option<E> = serde_json::from_str(&content).ok();
-            Err(Error::ResponseError(ResponseContent {
-                status,
-                content,
-                entity,
-            }))
-        }
-    }
-}
-
-#[async_trait]
-impl<T, E> FromResponse<E> for Conditional<T>
-where
-    T: serde::de::DeserializeOwned,
-    E: serde::de::DeserializeOwned,
-{
-    async fn from_response(resp: reqwest::Response) -> Result<Self, Error<E>> {
-        if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
-            return Ok(Conditional::NotModified);
-        }
-        // Capture the ETag before consuming the response body.
-        let etag = resp
-            .headers()
-            .get(reqwest::header::ETAG)
-            .and_then(|v| v.to_str().ok())
-            .map(str::to_owned);
-        let status = resp.status();
-        let content = resp.text().await?;
-        if !status.is_client_error() && !status.is_server_error() {
-            let body = if content.is_empty() { "null" } else { &content };
-            let value = serde_json::from_str(body).map_err(Error::from)?;
-            Ok(Conditional::Modified { value, etag })
-        } else {
-            let entity: Option<E> = serde_json::from_str(&content).ok();
-            Err(Error::ResponseError(ResponseContent {
-                status,
-                content,
-                entity,
-            }))
-        }
-    }
-}
-
-pub(crate) async fn fetch<R, T, E>(
+pub(crate) async fn fetch_inner<R, E>(
     configuration: &configuration::Configuration,
     method: reqwest::Method,
     prefix: Option<&str>,
@@ -79,10 +12,9 @@ pub(crate) async fn fetch<R, T, E>(
     request: &R,
     headers: Option<HashMap<String, String>>,
     query_params: Option<HashMap<String, String>>,
-) -> Result<T, Error<E>>
+) -> Result<reqwest::Response, Error<E>>
 where
     R: serde::Serialize + ?Sized,
-    T: FromResponse<E>,
 {
     let uri_base = build_uri_base(configuration, prefix);
     let client = &configuration.client;
@@ -135,11 +67,10 @@ where
     }
 
     let req = req_builder.build()?;
-    let resp = client.execute(req).await?;
-    T::from_response(resp).await
+    client.execute(req).await.map_err(Error::from)
 }
 
-pub(crate) async fn fetch_empty<R, E>(
+pub(crate) async fn fetch<R, T, E>(
     configuration: &configuration::Configuration,
     method: reqwest::Method,
     prefix: Option<&str>,
@@ -147,21 +78,64 @@ pub(crate) async fn fetch_empty<R, E>(
     request: &R,
     headers: Option<HashMap<String, String>>,
     query_params: Option<HashMap<String, String>>,
-) -> Result<(), Error<E>>
+) -> Result<T, Error<E>>
 where
     R: serde::Serialize + ?Sized,
+    T: serde::de::DeserializeOwned,
     E: serde::de::DeserializeOwned,
 {
-    fetch(
-        configuration,
-        method,
-        prefix,
-        uri_str,
-        request,
-        headers,
-        query_params,
-    )
-    .await
+    let resp = fetch_inner(configuration, method, prefix, uri_str, request, headers, query_params).await?;
+    let status = resp.status();
+    let content = resp.text().await?;
+    if !status.is_client_error() && !status.is_server_error() {
+        let body = if content.is_empty() { "null" } else { &content };
+        serde_json::from_str(body).map_err(Error::from)
+    } else {
+        let entity: Option<E> = serde_json::from_str(&content).ok();
+        Err(Error::ResponseError(ResponseContent {
+            status,
+            content,
+            entity,
+        }))
+    }
+}
+
+pub(crate) async fn fetch_conditional<R, T, E>(
+    configuration: &configuration::Configuration,
+    method: reqwest::Method,
+    prefix: Option<&str>,
+    uri_str: &str,
+    request: &R,
+    headers: Option<HashMap<String, String>>,
+    query_params: Option<HashMap<String, String>>,
+) -> Result<Conditional<T>, Error<E>>
+where
+    R: serde::Serialize + ?Sized,
+    T: serde::de::DeserializeOwned,
+    E: serde::de::DeserializeOwned,
+{
+    let resp = fetch_inner(configuration, method, prefix, uri_str, request, headers, query_params).await?;
+    if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
+        return Ok(Conditional::NotModified);
+    }
+    let resp_headers = resp.headers().clone();
+    let status = resp.status();
+    let content = resp.text().await?;
+    if !status.is_client_error() && !status.is_server_error() {
+        let body = if content.is_empty() { "null" } else { &content };
+        let value = serde_json::from_str(body).map_err(Error::from)?;
+        Ok(Conditional::Modified {
+            value,
+            headers: resp_headers,
+        })
+    } else {
+        let entity: Option<E> = serde_json::from_str(&content).ok();
+        Err(Error::ResponseError(ResponseContent {
+            status,
+            content,
+            entity,
+        }))
+    }
 }
 
 /// Build the base URI for REST API calls with proper prefix encoding

--- a/catalogs/iceberg-rest-catalog/src/apis/mod.rs
+++ b/catalogs/iceberg-rest-catalog/src/apis/mod.rs
@@ -15,8 +15,11 @@ pub struct ResponseContent<T> {
 pub enum Conditional<T> {
     /// Server returned `304 Not Modified`; the caller's cached value is still current.
     NotModified,
-    /// Server returned a fresh body, along with its `ETag` if one was present.
-    Modified { value: T, etag: Option<String> },
+    /// Server returned a fresh body along with all HTTP response headers.
+    Modified {
+        value: T,
+        headers: reqwest::header::HeaderMap,
+    },
 }
 
 #[derive(Debug)]
@@ -114,6 +117,5 @@ pub mod configuration_api_api;
 pub(crate) mod fetch;
 pub mod o_auth2_api_api;
 
-pub use fetch::FromResponse;
 
 pub mod configuration;

--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -359,10 +359,6 @@ impl Catalog for RestCatalog {
                     .await
                     .map_err(|_| Error::CatalogNotFound)?;
 
-                    let apis::Conditional::Modified { value: response, .. } = response else {
-                        return Err(Error::CatalogNotFound);
-                    };
-
                     let object_store = self.get_object_store(&response)?;
 
                     self.cache

--- a/catalogs/iceberg-rest-catalog/src/catalog.rs
+++ b/catalogs/iceberg-rest-catalog/src/catalog.rs
@@ -359,6 +359,10 @@ impl Catalog for RestCatalog {
                     .await
                     .map_err(|_| Error::CatalogNotFound)?;
 
+                    let apis::Conditional::Modified { value: response, .. } = response else {
+                        return Err(Error::CatalogNotFound);
+                    };
+
                     let object_store = self.get_object_store(&response)?;
 
                     self.cache


### PR DESCRIPTION
Builds on #372.

I would like to avoid the FromResponse trait. I refactored the same logic into a `fetch_inner` method and created a fetch_conditional wrapper. I think it should solve the same issue.

Additionally extended the Conditional struct to include also other response headers. To be able to use it for vended-credentials.